### PR TITLE
fix: Rebase Designer Trial SCSS onto latest platform

### DIFF
--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Formats/WebWorks Reverb 2.0/Pages/sass/_colors.scss
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Formats/WebWorks Reverb 2.0/Pages/sass/_colors.scss
@@ -256,9 +256,10 @@ $share_popup_label_color: $_layout_color_2;
 $share_popup_input_background_color: $_layout_color_3;
 $share_popup_input_text_color: $_layout_color_2;
 $share_popup_input_border_color: darken($_layout_color_3, 10%);
-$share_popup_copy_button_background_color: $_layout_color_1;
-$share_popup_copy_button_text_color: $_layout_color_4;
-$share_popup_copy_button_background_color_hover: darken($_layout_color_1, 10%);
+$share_popup_copy_button_icon_color: $_layout_color_2;
+$share_popup_copy_button_copied_icon_color: #28a745;
+$share_popup_copy_button_background_color: $share_popup_background_color;
+$share_popup_copy_button_background_color_hover: darken($share_popup_copy_button_background_color, 10%);
 
 /* disqus */
 $disqus_background_color: $_layout_color_3;

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Formats/WebWorks Reverb 2.0/Pages/sass/skin.scss
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Formats/WebWorks Reverb 2.0/Pages/sass/skin.scss
@@ -464,7 +464,7 @@ a.ww_skin {
   font-size: 13px;
   font-family: inherit;
   font-weight: 500;
-  color: $share_popup_copy_button_text_color;
+  color: $share_popup_copy_button_icon_color;
   background: $share_popup_copy_button_background_color;
   border: 1px solid $share_popup_copy_button_background_color;
   border-radius: 0 4px 4px 0;
@@ -472,14 +472,24 @@ a.ww_skin {
   transition: background 0.15s ease;
   white-space: nowrap;
 
+  i:before {
+    content: $share_popup_copy_button_icon;
+  }
+
   &:hover, &:focus {
     background: $share_popup_copy_button_background_color_hover;
-    border-color: $share_popup_copy_button_background_color_hover;
   }
 
   &.ww_skin_share_popup_copy_button_copied {
-    background: #28a745;
-    border-color: #28a745;
+    color: $share_popup_copy_button_copied_icon_color;
+
+    &:hover, &:focus {
+      background: none;
+    }
+
+    i:before {
+      content: $share_popup_copy_button_copied_icon;
+    }
   }
 }
 
@@ -1722,10 +1732,9 @@ div.ww_skin_toolbar_logo {
   text-align: center;
 
   img {
-    width: 100%;
-    height: auto;
     max-width: 80vw;
     max-height: 80vh;
+    object-fit: contain;
   }
 }
 


### PR DESCRIPTION
## Summary

- Rebase `skin.scss` onto latest ePublisher platform version — picks up share popup icon variables, copied-state styling, and lightbox `object-fit: contain`
- Update `_colors.scss` share popup copy button variables to match platform's new icon-based API (`$share_popup_copy_button_icon_color`, `$share_popup_copy_button_copied_icon_color`)
- All intentional `$theme_*` customizations preserved; only stale base code updated

## Test plan

- [ ] `diff skin.scss` against platform shows only the appended `@import "custom-skin"` line
- [ ] `diff _colors.scss` against platform shows only intentional `$theme_*` customizations
- [ ] AutoMap rebuild produces correct output with no SCSS compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)