### PR TITLE
Apply Markdown++ triple pattern to trial source docs

### DIFF
--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/title.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/title.md
@@ -1,6 +1,8 @@
-<!-- markers:{"Keywords": "quantum sync, documentation, cloud storage, file synchronization, user guide", "Description": "Complete user guide for Quantum Sync — a cloud file synchronization service with real-time sync, version history, and end-to-end encryption."} -->
+<!-- markers:{"Keywords": "quantum sync, documentation, cloud storage, file synchronization, user guide", "Description": "Complete user guide for Quantum Sync — a cloud file synchronization service with real-time sync, version history, and end-to-end encryption."}; #documentation -->
 $ProductName; Documentation
 ============================
+
+[documentation]: #documentation "Documentation"
 
 Welcome to the $ProductName; $Version; documentation.
 

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/conditions-and-variables.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/conditions-and-variables.md
@@ -1,10 +1,14 @@
 <!-- markers:{"Keywords": "settings, configuration, preferences, bandwidth, notifications, proxy, admin", "Description": "Configure Quantum Sync preferences including sync behavior, bandwidth limits, and notifications.", "IndexMarker": "settings:configuring,configuration:preferences"}; #settings -->
 ## Settings
 
+[settings]: #settings "Settings"
+
 $ProductName; $Version; provides extensive configuration options to customize sync behavior for your environment. Access settings through the system tray icon (Windows and Linux) or menu bar application (macOS).
 
 <!-- marker:IndexMarker="settings:general" ; #general-settings -->
 ### General Settings
+
+[general-settings]: #general-settings "General Settings"
 
 | Setting | Description | Default |
 |---------|-------------|---------|
@@ -17,6 +21,8 @@ $ProductName; $Version; provides extensive configuration options to customize sy
 <!-- marker:IndexMarker="settings:sync,bandwidth:limiting" ; #sync-settings -->
 ### Sync Settings
 
+[sync-settings]: #sync-settings "Sync Settings"
+
 | Setting | Description | Default |
 |---------|-------------|---------|
 | Sync folder location | Local directory for synchronized files | `Documents/$ProductName;` |
@@ -27,6 +33,8 @@ $ProductName; $Version; provides extensive configuration options to customize sy
 
 <!-- marker:IndexMarker="settings:network,proxy:configuration" ; #network-settings -->
 ### Network Settings
+
+[network-settings]: #network-settings "Network Settings"
 
 Configure proxy servers and network preferences for environments with restricted internet access.
 
@@ -44,6 +52,8 @@ Configure proxy servers and network preferences for environments with restricted
 <!-- condition:advanced -->
 <!-- marker:IndexMarker="settings:administrator,enterprise:deployment" ; #admin-settings -->
 ### Administrator Settings
+
+[admin-settings]: #admin-settings "Administrator Settings"
 
 The following settings are available only to users with administrator privileges or when $ProductName; is deployed through enterprise management tools.
 

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/content-islands.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/content-islands.md
@@ -1,10 +1,14 @@
 <!-- markers:{"Keywords": "sync modes, automatic, manual, selective, bandwidth, callouts, tips, warnings", "Description": "Synchronization modes and bandwidth management for Quantum Sync.", "IndexMarker": "synchronization:modes"}; #sync-modes -->
 ## Sync Modes
 
+[sync-modes]: #sync-modes "Sync Modes"
+
 $ProductName; offers three synchronization modes to accommodate different workflows and network conditions. You can switch between modes at any time through the application settings or system tray menu.
 
 <!-- marker:IndexMarker="synchronization:automatic,real-time synchronization" ; #automatic-sync -->
 ### Automatic Sync
+
+[automatic-sync]: #automatic-sync "Automatic Sync"
 
 In automatic mode, $ProductName; monitors your sync folder continuously and uploads changes immediately. Downloads from other devices appear as soon as they are available. This mode is ideal for desktop computers with reliable internet connections.
 
@@ -14,12 +18,14 @@ Automatic sync uses intelligent scheduling to avoid interfering with your work:
 - **Idle periods** — Transfer speeds increase to synchronize queued changes quickly
 - **Metered connections** — Sync pauses automatically when your operating system reports a metered network
 
-> **Tip:** You can override the metered connection behavior in [Sync Settings](conditions-and-variables.md#sync-settings). Set **Pause sync on battery** to *Disabled* if you want sync to continue during battery-powered sessions.
+> **Tip:** You can override the metered connection behavior in [Sync Settings][sync-settings]. Set **Pause sync on battery** to *Disabled* if you want sync to continue during battery-powered sessions.
 
 ---
 
 <!-- marker:IndexMarker="synchronization:manual" ; #manual-sync -->
 ### Manual Sync
+
+[manual-sync]: #manual-sync "Manual Sync"
 
 Manual mode gives you complete control over when synchronization occurs. Changes are queued locally and transmitted only when you explicitly trigger a sync. This mode is useful when traveling or on metered cellular connections.
 
@@ -35,6 +41,8 @@ You can trigger a manual sync in three ways:
 
 <!-- marker:IndexMarker="synchronization:selective,storage:conservation" ; #selective-sync -->
 ### Selective Sync
+
+[selective-sync]: #selective-sync "Selective Sync"
 
 Selective sync allows you to choose which cloud folders appear on each device. Folders you exclude are hidden from your local sync folder but remain accessible through the web interface and on other devices.
 
@@ -56,6 +64,8 @@ Use selective sync to conserve disk space on laptops, separate work and personal
 <!-- #choosing-mode -->
 ### Choosing the Right Mode
 
+[choosing-mode]: #choosing-mode "Choosing the Right Mode"
+
 If you are unsure which mode to use, consider the following guidelines:
 
 - Use **Automatic** if you have a reliable, unmetered internet connection and want files available everywhere without intervention
@@ -69,6 +79,8 @@ If you are unsure which mode to use, consider the following guidelines:
 <!-- marker:IndexMarker="bandwidth:management,network:optimization" ; #bandwidth-management -->
 ### Bandwidth Management
 
+[bandwidth-management]: #bandwidth-management "Bandwidth Management"
+
 $ProductName; allows you to limit upload and download speeds to avoid saturating your network connection. This is especially useful in shared office environments or on connections with limited throughput.
 
 <!-- style:BQ Tip -->
@@ -81,7 +93,7 @@ $ProductName; allows you to limit upload and download speeds to avoid saturating
 > | Mobile hotspot  | 100 KB/s     | 250 KB/s       |
 > | Satellite       | 50 KB/s      | 100 KB/s       |
 >
-> Configure these values in [Sync Settings](conditions-and-variables.md#sync-settings). Set a limit to **0** for unlimited throughput.
+> Configure these values in [Sync Settings][sync-settings]. Set a limit to **0** for unlimited throughput.
 
 To check your current bandwidth usage, use the command-line tool:
 
@@ -102,4 +114,21 @@ To check your current bandwidth usage, use the command-line tool:
 >
 > Press `Ctrl+C` to stop monitoring.
 
-For additional information about network configuration, see [Network Settings](conditions-and-variables.md#network-settings). If you experience slow transfers, see [Slow sync performance](expandable-sections.md#issue-slow-performance) for optimization steps.
+For additional information about network configuration, see [Network Settings][network-settings]. If you experience slow transfers, see [Slow sync performance][issue-slow-performance] for optimization steps.
+
+<!--
+  Cross-file slug definitions (pattern-file artifact).
+
+  The Designer Trial source docs are pattern files for modular development.
+  Each topic file is registered as a separate source document in the .wep, not
+  assembled via includes. So `[Text][slug]` cross-references need each outgoing
+  slug defined locally per CommonMark scope rules. In a production setup where
+  topic files are assembled via include directives, these local defs would not
+  be needed — each target file's triple already places the slug in
+  document-global scope after Phase 1 assembly. Maintaining this block by hand
+  is not the expected real-world workflow.
+-->
+
+[sync-settings]: conditions-and-variables.md#sync-settings "Sync Settings"
+[network-settings]: conditions-and-variables.md#network-settings "Network Settings"
+[issue-slow-performance]: expandable-sections.md#issue-slow-performance "Slow sync performance"

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/expandable-sections.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/expandable-sections.md
@@ -1,12 +1,16 @@
 <!-- markers:{"Keywords": "troubleshooting, errors, sync issues, conflicts, diagnostics, support, performance", "Description": "Resolve common Quantum Sync issues including sync failures, conflicts, connection problems, and performance."}; #troubleshooting -->
 ## Troubleshooting
 
+[troubleshooting]: #troubleshooting "Troubleshooting"
+
 This section covers common issues and their solutions. If you cannot resolve a problem using the steps below, contact support at $SupportEmail;.
 
 ### Common Issues
 
 <!-- style:Issue ; marker:IndexMarker="troubleshooting:files not syncing" ; #issue-files-not-syncing -->
 #### Files not syncing
+
+[issue-files-not-syncing]: #issue-files-not-syncing "Files not syncing"
 
 If files in your sync folder are not uploading or downloading:
 
@@ -24,7 +28,9 @@ quantumsync service restart
 <!-- style:Issue ; marker:IndexMarker="troubleshooting:sync conflicts,conflicts:resolving" ; #issue-sync-conflicts -->
 #### Sync conflicts
 
-[Conflicts](glossary.md#gloss-term-conflict) occur when the same file is modified on multiple devices before syncing completes. $ProductName; preserves both versions by renaming the conflicting copy with a timestamp suffix (for example, `report (conflicted 2026-03-01).docx`).
+[issue-sync-conflicts]: #issue-sync-conflicts "Sync conflicts"
+
+[Conflicts][gloss-term-conflict] occur when the same file is modified on multiple devices before syncing completes. $ProductName; preserves both versions by renaming the conflicting copy with a timestamp suffix (for example, `report (conflicted 2026-03-01).docx`).
 
 To resolve a conflict:
 
@@ -37,6 +43,8 @@ To resolve a conflict:
 <!-- style:Issue ; marker:IndexMarker="troubleshooting:connection errors,network:ports" ; #issue-connection-errors -->
 #### Connection errors
 
+[issue-connection-errors]: #issue-connection-errors "Connection errors"
+
 If $ProductName; cannot connect to the server, check your network settings and firewall configuration. The application requires outbound access on the following ports:
 
 | Port | Protocol | Purpose |
@@ -44,14 +52,16 @@ If $ProductName; cannot connect to the server, check your network settings and f
 | 443  | HTTPS    | API communication and file transfer |
 | 8443 | WebSocket| Real-time change notifications |
 
-If your organization uses a proxy server, configure it in [Network Settings](conditions-and-variables.md#network-settings).
+If your organization uses a proxy server, configure it in [Network Settings][network-settings].
 
 <!-- style:Issue ; marker:IndexMarker="troubleshooting:slow sync,performance:optimization" ; #issue-slow-performance -->
 #### Slow sync performance
 
+[issue-slow-performance]: #issue-slow-performance "Slow sync performance"
+
 If file synchronization is slower than expected:
 
-1. **Check bandwidth limits** — Open [Sync Settings](conditions-and-variables.md#sync-settings) and verify that upload and download limits are not set too low
+1. **Check bandwidth limits** — Open [Sync Settings][sync-settings] and verify that upload and download limits are not set too low
 2. **Reduce concurrent transfers** — If you are syncing thousands of small files, $ProductName; may perform better with fewer concurrent connections
 3. **Switch to a wired connection** — Ethernet connections provide more consistent throughput than Wi-Fi
 4. **Exclude unnecessary files** — Add large temporary files and build artifacts to your ignore patterns:
@@ -67,6 +77,8 @@ If file synchronization is slower than expected:
 <!-- style:Issue ; #issue-high-cpu-usage -->
 #### High CPU usage
 
+[issue-high-cpu-usage]: #issue-high-cpu-usage "High CPU usage"
+
 If $ProductName; uses excessive CPU resources:
 
 - Check whether a large initial sync is in progress (first sync after installation is resource-intensive)
@@ -75,6 +87,8 @@ If $ProductName; uses excessive CPU resources:
 
 <!-- marker:IndexMarker="diagnostics:commands,troubleshooting:diagnostic tools" ; #diagnostics -->
 ### Diagnostic Tools
+
+[diagnostics]: #diagnostics "Diagnostic Tools"
 
 Use the built-in diagnostic tool to gather information for support requests:
 
@@ -110,6 +124,8 @@ For additional troubleshooting steps, see the online knowledge base at quantumsy
 <!-- #getting-help -->
 ### Getting Help
 
+[getting-help]: #getting-help "Getting Help"
+
 If you cannot resolve your issue using the steps above:
 
 - Search the knowledge base at quantumsync.example/support
@@ -120,4 +136,22 @@ If you cannot resolve your issue using the steps above:
 When contacting support, include the output of `quantumsync --diagnose` to help the support team identify your issue quickly.
 <!-- /condition -->
 
-For definitions of technical terms used in this section, see the [Glossary](glossary.md#glossary).
+For definitions of technical terms used in this section, see the [Glossary][glossary].
+
+<!--
+  Cross-file slug definitions (pattern-file artifact).
+
+  The Designer Trial source docs are pattern files for modular development.
+  Each topic file is registered as a separate source document in the .wep, not
+  assembled via includes. So `[Text][slug]` cross-references need each outgoing
+  slug defined locally per CommonMark scope rules. In a production setup where
+  topic files are assembled via include directives, these local defs would not
+  be needed — each target file's triple already places the slug in
+  document-global scope after Phase 1 assembly. Maintaining this block by hand
+  is not the expected real-world workflow.
+-->
+
+[gloss-term-conflict]: glossary.md#gloss-term-conflict "Conflict"
+[network-settings]: conditions-and-variables.md#network-settings "Network Settings"
+[sync-settings]: conditions-and-variables.md#sync-settings "Sync Settings"
+[glossary]: glossary.md#glossary "Glossary"

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/glossary.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/glossary.md
@@ -1,64 +1,126 @@
 <!-- markers:{"Keywords": "glossary, definitions, terms, terminology, reference", "Description": "Definitions of technical terms used throughout the Quantum Sync documentation."}; #glossary -->
 ## Glossary
 
+[glossary]: #glossary "Glossary"
+
 This glossary defines technical terms used throughout the $ProductName; documentation.
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:conflict" ; #gloss-term-conflict -->
 ### Conflict:
 
+[gloss-term-conflict]: #gloss-term-conflict "Conflict"
+
 <!-- style:Glossary Def ; #gloss-def-conflict -->
-A situation where the same file is modified on two or more devices before synchronization completes. $ProductName; resolves conflicts by keeping both versions and adding a timestamp to the filename of the secondary copy. See [Troubleshooting](expandable-sections.md#issue-sync-conflicts) for conflict resolution steps.
+A situation where the same file is modified on two or more devices before synchronization completes. $ProductName; resolves conflicts by keeping both versions and adding a timestamp to the filename of the secondary copy. See [Troubleshooting][issue-sync-conflicts] for conflict resolution steps.
+
+[gloss-def-conflict]: #gloss-def-conflict "Conflict definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:delta sync" ; #gloss-term-delta-sync -->
 ### Delta Sync:
 
+[gloss-term-delta-sync]: #gloss-term-delta-sync "Delta Sync"
+
 <!-- style:Glossary Def ; #gloss-def-delta-sync -->
 A synchronization technique that transmits only the changed portions of a file rather than the entire file. Delta sync significantly reduces bandwidth usage and sync time, especially for large files with small modifications.
+
+[gloss-def-delta-sync]: #gloss-def-delta-sync "Delta Sync definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:encryption,encryption:definition" ; #gloss-term-encryption -->
 ### Encryption:
 
+[gloss-term-encryption]: #gloss-term-encryption "Encryption"
+
 <!-- style:Glossary Def ; #gloss-def-encryption -->
-The process of encoding data so that only authorized parties can read it. $ProductName; uses AES-256 encryption for data at rest and TLS 1.3 for data in transit. See [End-to-End Encryption](tables.md#core-capabilities) for details.
+The process of encoding data so that only authorized parties can read it. $ProductName; uses AES-256 encryption for data at rest and TLS 1.3 for data in transit. See [End-to-End Encryption][core-capabilities] for details.
+
+[gloss-def-encryption]: #gloss-def-encryption "Encryption definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:ignore pattern" ; #gloss-term-ignore-pattern -->
 ### Ignore Pattern:
 
+[gloss-term-ignore-pattern]: #gloss-term-ignore-pattern "Ignore Pattern"
+
 <!-- style:Glossary Def ; #gloss-def-ignore-pattern -->
-A file name pattern that tells $ProductName; to skip matching files during synchronization. Common ignore patterns include `*.tmp`, `*.log`, and `node_modules/`. Configure ignore patterns in [Sync Settings](conditions-and-variables.md#sync-settings).
+A file name pattern that tells $ProductName; to skip matching files during synchronization. Common ignore patterns include `*.tmp`, `*.log`, and `node_modules/`. Configure ignore patterns in [Sync Settings][sync-settings].
+
+[gloss-def-ignore-pattern]: #gloss-def-ignore-pattern "Ignore Pattern definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:metered connection" ; #gloss-term-metered-connection -->
 ### Metered Connection:
 
+[gloss-term-metered-connection]: #gloss-term-metered-connection "Metered Connection"
+
 <!-- style:Glossary Def ; #gloss-def-metered-connection -->
 A network connection with limited data allowance, such as cellular data or some Wi-Fi hotspots. $ProductName; can detect metered connections and pause automatic sync to avoid unexpected data charges.
+
+[gloss-def-metered-connection]: #gloss-def-metered-connection "Metered Connection definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:retention period" ; #gloss-term-retention-period -->
 ### Retention Period:
 
+[gloss-term-retention-period]: #gloss-term-retention-period "Retention Period"
+
 <!-- style:Glossary Def ; #gloss-def-retention-period -->
-The length of time that $ProductName; keeps previous versions of your files. The retention period varies by plan: 30 days for Personal, 90 days for Team, and 180 days for Enterprise. See the [Plan Comparison](tables.md#plan-comparison) for details.
+The length of time that $ProductName; keeps previous versions of your files. The retention period varies by plan: 30 days for Personal, 90 days for Team, and 180 days for Enterprise. See the [Plan Comparison][plan-comparison] for details.
+
+[gloss-def-retention-period]: #gloss-def-retention-period "Retention Period definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:selective sync" ; #gloss-term-selective-sync -->
 ### Selective Sync:
 
+[gloss-term-selective-sync]: #gloss-term-selective-sync "Selective Sync"
+
 <!-- style:Glossary Def ; #gloss-def-selective-sync -->
-A feature that allows you to choose which cloud folders sync to each device. Files in unselected folders remain in your cloud storage but do not consume local disk space. See [Selective Sync](content-islands.md#selective-sync) for configuration instructions.
+A feature that allows you to choose which cloud folders sync to each device. Files in unselected folders remain in your cloud storage but do not consume local disk space. See [Selective Sync][selective-sync] for configuration instructions.
+
+[gloss-def-selective-sync]: #gloss-def-selective-sync "Selective Sync definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:sync folder" ; #gloss-term-sync-folder -->
 ### Sync Folder:
 
+[gloss-term-sync-folder]: #gloss-term-sync-folder "Sync Folder"
+
 <!-- style:Glossary Def ; #gloss-def-sync-folder -->
-The local directory where $ProductName; stores synchronized files. By default, this is located in your Documents folder. You can change the sync folder location in [Sync Settings](conditions-and-variables.md#sync-settings).
+The local directory where $ProductName; stores synchronized files. By default, this is located in your Documents folder. You can change the sync folder location in [Sync Settings][sync-settings].
+
+[gloss-def-sync-folder]: #gloss-def-sync-folder "Sync Folder definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:version history" ; #gloss-term-version-history -->
 ### Version History:
 
+[gloss-term-version-history]: #gloss-term-version-history "Version History"
+
 <!-- style:Glossary Def ; #gloss-def-version-history -->
-A record of previous versions of each file, maintained automatically by $ProductName;. You can restore or download any previous version within the [retention period](#gloss-term-retention-period). See [Version History](tables.md#core-capabilities) for retention policy details.
+A record of previous versions of each file, maintained automatically by $ProductName;. You can restore or download any previous version within the [retention period][gloss-term-retention-period]. See [Version History][core-capabilities] for retention policy details.
+
+[gloss-def-version-history]: #gloss-def-version-history "Version History definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="glossary:zero-knowledge encryption" ; #gloss-term-zero-knowledge -->
 ### Zero-Knowledge Encryption:
 
+[gloss-term-zero-knowledge]: #gloss-term-zero-knowledge "Zero-Knowledge Encryption"
+
 <!-- style:Glossary Def ; #gloss-def-zero-knowledge -->
-A security model where the service provider cannot decrypt your files, even if compelled by legal authority. Only you hold the encryption keys. $ProductName; offers zero-knowledge encryption as an optional setting for organizations with strict compliance requirements. See [Security Model](headings-and-text.md#key-benefits) for an overview.
+A security model where the service provider cannot decrypt your files, even if compelled by legal authority. Only you hold the encryption keys. $ProductName; offers zero-knowledge encryption as an optional setting for organizations with strict compliance requirements. See [Security Model][key-benefits] for an overview.
+
+[gloss-def-zero-knowledge]: #gloss-def-zero-knowledge "Zero-Knowledge Encryption definition"
+
+<!--
+  Cross-file slug definitions (pattern-file artifact).
+
+  The Designer Trial source docs are pattern files for modular development.
+  Each topic file is registered as a separate source document in the .wep, not
+  assembled via includes. So `[Text][slug]` cross-references need each outgoing
+  slug defined locally per CommonMark scope rules. In a production setup where
+  topic files are assembled via include directives, these local defs would not
+  be needed — each target file's triple already places the slug in
+  document-global scope after Phase 1 assembly. Maintaining this block by hand
+  is not the expected real-world workflow.
+-->
+
+[issue-sync-conflicts]: expandable-sections.md#issue-sync-conflicts "Sync conflicts"
+[core-capabilities]: tables.md#core-capabilities "Core Capabilities"
+[sync-settings]: conditions-and-variables.md#sync-settings "Sync Settings"
+[plan-comparison]: tables.md#plan-comparison "Feature Comparison by Plan"
+[selective-sync]: content-islands.md#selective-sync "Selective Sync"
+[key-benefits]: headings-and-text.md#key-benefits "Key Benefits"

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/headings-and-text.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/headings-and-text.md
@@ -1,12 +1,16 @@
 <!-- markers:{"Keywords": "quantum sync, overview, cloud storage, file synchronization, benefits, architecture", "Description": "Learn what Quantum Sync is and why it is the ideal solution for cloud file synchronization.", "IndexMarker": "cloud synchronization"}; #overview -->
 ## Overview
 
+[overview]: #overview "Overview"
+
 $ProductName; is a next-generation cloud synchronization service designed for teams and individuals who need reliable, secure file access across all their devices. Built with **enterprise-grade security** and *consumer-friendly simplicity*, $ProductName; bridges the gap between powerful functionality and ease of use.
 
 Whether you are a solo professional managing documents across laptops and tablets, or an enterprise IT administrator deploying to thousands of users, $ProductName; adapts to your workflow. Our intelligent sync engine detects changes in real time and propagates them across your connected devices with minimal bandwidth usage.
 
 <!-- #key-benefits -->
 ### Key Benefits
+
+[key-benefits]: #key-benefits "Key Benefits"
 
 $ProductName; offers several advantages over traditional file synchronization solutions:
 
@@ -17,18 +21,24 @@ $ProductName; offers several advantages over traditional file synchronization so
 - **Selective sync** — Choose which folders to sync on each device to conserve storage space
 - ~~Legacy FTP uploads~~ — Replaced by the modern sync engine in $ProductName; $Version;
 
-<!-- marker:IndexMarker="real-time synchronization" -->
+<!-- marker:IndexMarker="real-time synchronization" ; #real-time-performance -->
 #### Real-Time Performance
+
+[real-time-performance]: #real-time-performance "Real-Time Performance"
 
 Unlike polling-based sync services that check for changes every few minutes, $ProductName; uses a persistent connection to detect file changes the moment they happen. The sync engine uses `delta compression` to transmit only the bytes that changed, reducing bandwidth by up to 90% compared to full-file transfers.
 
-<!-- marker:IndexMarker="encryption:AES-256,security:overview" -->
+<!-- marker:IndexMarker="encryption:AES-256,security:overview" ; #security-model -->
 #### Security Model
+
+[security-model]: #security-model "Security Model"
 
 Every file is encrypted with AES-256 before leaving your device. During transfer, TLS 1.3 protects data in transit. For organizations with strict compliance requirements, $ProductName; offers **zero-knowledge encryption** where even our servers cannot read your data.
 
 <!-- #architecture -->
 ### Architecture
+
+[architecture]: #architecture "Architecture"
 
 $ProductName; uses a distributed architecture with regional data centers to ensure low latency and high availability. The diagram below illustrates how data flows through the system.
 
@@ -40,4 +50,20 @@ The architecture consists of three tiers:
 2. **Edge tier** — Regional relay servers that route traffic to the nearest data center
 3. **Storage tier** — Distributed cloud storage with automatic replication
 
-For detailed information about specific capabilities, see the [Features](tables.md#features) section. To configure $ProductName; for your environment, see the [Settings](conditions-and-variables.md#settings) section.
+For detailed information about specific capabilities, see the [Features][features] section. To configure $ProductName; for your environment, see the [Settings][settings] section.
+
+<!--
+  Cross-file slug definitions (pattern-file artifact).
+
+  The Designer Trial source docs are pattern files for modular development.
+  Each topic file is registered as a separate source document in the .wep, not
+  assembled via includes. So `[Text][slug]` cross-references need each outgoing
+  slug defined locally per CommonMark scope rules. In a production setup where
+  topic files are assembled via include directives, these local defs would not
+  be needed — each target file's triple already places the slug in
+  document-global scope after Phase 1 assembly. Maintaining this block by hand
+  is not the expected real-world workflow.
+-->
+
+[features]: tables.md#features "Features"
+[settings]: conditions-and-variables.md#settings "Settings"

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/procedures.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/procedures.md
@@ -1,10 +1,14 @@
 <!-- markers:{"Keywords": "getting started, setup, installation, quickstart, prerequisites", "Description": "Step-by-step guide to installing and configuring Quantum Sync on your device.", "IndexMarker": "installation,setup:initial"}; #getting-started -->
 ## Getting Started
 
+[getting-started]: #getting-started "Getting Started"
+
 This guide walks you through the initial setup of $ProductName; on your device. The entire process takes approximately five minutes.
 
 <!-- #prerequisites -->
 ### Prerequisites
+
+[prerequisites]: #prerequisites "Prerequisites"
 
 Before you begin, ensure you have the following:
 
@@ -22,6 +26,8 @@ Before you begin, ensure you have the following:
 
 <!-- style:Procedure Title ; #installation -->
 To install $ProductName; on your device:
+
+[installation]: #installation "Install Quantum Sync"
 
 1. **Download the installer**
 
@@ -59,12 +65,14 @@ To install $ProductName; on your device:
 
 5. **Configure initial sync**
 
-   Select which existing cloud folders to sync to this device. You can change these settings later in [Settings](conditions-and-variables.md#settings).
+   Select which existing cloud folders to sync to this device. You can change these settings later in [Settings][settings].
 
 > **Tip:** For the fastest initial sync, connect to a wired network. $ProductName; downloads large file sets significantly faster over Ethernet than Wi-Fi.
 
 <!-- #verify-installation -->
 ### Verifying Your Installation
+
+[verify-installation]: #verify-installation "Verifying Your Installation"
 
 After installation, confirm that $ProductName; is running correctly:
 
@@ -73,10 +81,12 @@ After installation, confirm that $ProductName; is running correctly:
 3. Verify the status reads **Connected** and your account email appears
 4. Create a test file in your sync folder and confirm it appears at quantumsync.example/files
 
-If the status shows **Disconnected** or **Error**, see [Troubleshooting](expandable-sections.md#troubleshooting) for solutions.
+If the status shows **Disconnected** or **Error**, see [Troubleshooting][troubleshooting] for solutions.
 
 <!-- style:Heading 3 ; #command-line-verification -->
 ### Command-Line Verification
+
+[command-line-verification]: #command-line-verification "Command-Line Verification"
 
 <!-- condition:advanced -->
 Advanced users can verify the installation from the command line:
@@ -95,6 +105,8 @@ The `--diagnose` command runs a connectivity test and reports any configuration 
 <!-- style:Procedure Title ; #configure-selective-sync -->
 To choose which cloud folders sync to this device:
 
+[configure-selective-sync]: #configure-selective-sync "Configure Selective Sync"
+
 1. Open $ProductName; settings
 2. Navigate to the **Selective Sync** tab
 3. Review the list of cloud folders and their sizes
@@ -107,4 +119,21 @@ $ProductName; frees the associated disk space immediately. To re-enable a folder
 
 ### Next Steps
 
-After installation, $ProductName; runs in the background and keeps your files synchronized automatically. To learn about available capabilities, see [Features](tables.md#features). To customize sync behavior, see [Settings](conditions-and-variables.md#settings).
+After installation, $ProductName; runs in the background and keeps your files synchronized automatically. To learn about available capabilities, see [Features][features]. To customize sync behavior, see [Settings][settings].
+
+<!--
+  Cross-file slug definitions (pattern-file artifact).
+
+  The Designer Trial source docs are pattern files for modular development.
+  Each topic file is registered as a separate source document in the .wep, not
+  assembled via includes. So `[Text][slug]` cross-references need each outgoing
+  slug defined locally per CommonMark scope rules. In a production setup where
+  topic files are assembled via include directives, these local defs would not
+  be needed — each target file's triple already places the slug in
+  document-global scope after Phase 1 assembly. Maintaining this block by hand
+  is not the expected real-world workflow.
+-->
+
+[settings]: conditions-and-variables.md#settings "Settings"
+[troubleshooting]: expandable-sections.md#troubleshooting "Troubleshooting"
+[features]: tables.md#features "Features"

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/tables.md
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Source Docs/topics/tables.md
@@ -1,10 +1,14 @@
 <!-- markers:{"Keywords": "features, real-time sync, version history, sharing, encryption, collaboration, offline access", "Description": "Comprehensive overview of Quantum Sync features including sync, sharing, and security capabilities."}; #features -->
 ## Features
 
+[features]: #features "Features"
+
 $ProductName; $Version; includes a comprehensive set of features designed for both individual users and enterprise teams. This section provides detailed information about each major capability.
 
 <!-- #core-capabilities -->
 ### Core Capabilities
+
+[core-capabilities]: #core-capabilities "Core Capabilities"
 
 <!-- multiline ; marker:IndexMarker="synchronization:real-time,version history,sharing:secure,encryption:end-to-end,offline access" -->
 | Feature | Description |
@@ -47,6 +51,8 @@ $ProductName; $Version; includes a comprehensive set of features designed for bo
 <!-- marker:IndexMarker="platform support,system requirements" ; #platform-support -->
 ### Platform Support
 
+[platform-support]: #platform-support "Platform Support"
+
 $ProductName; runs natively on all major operating systems:
 
 | Platform | Minimum Version | Architecture | Installer |
@@ -60,6 +66,8 @@ $ProductName; runs natively on all major operating systems:
 
 <!-- #plan-comparison -->
 ### Feature Comparison by Plan
+
+[plan-comparison]: #plan-comparison "Feature Comparison by Plan"
 
 Not all features are available on every subscription tier. The following table summarizes availability across plans.
 
@@ -94,6 +102,8 @@ Contact $SupportEmail; for information about upgrading your account.
 
 <!-- marker:IndexMarker="API:overview,command line:integration" ; #api-access -->
 #### REST API
+
+[api-access]: #api-access "REST API"
 
 $ProductName; provides a REST API for programmatic access to sync operations. Common use cases include:
 

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/quantum-sync.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/quantum-sync.md
@@ -1,6 +1,8 @@
-<!-- markers:{"Keywords": "quantum sync, documentation, cloud storage, file synchronization", "Description": "Complete documentation for Quantum Sync cloud synchronization service"} -->
+<!-- markers:{"Keywords": "quantum sync, documentation, cloud storage, file synchronization", "Description": "Complete documentation for Quantum Sync cloud synchronization service"}; #documentation -->
 Quantum Sync Documentation
 ==========================
+
+[documentation]: #documentation "Documentation"
 
 Welcome to the $ProductName; documentation. This guide covers everything you need to know about setting up and using $ProductName; for seamless cloud file synchronization.
 

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/features.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/features.md
@@ -1,6 +1,8 @@
 <!-- markers:{"Keywords": "features, real-time sync, version history, sharing, encryption, collaboration", "Description": "Comprehensive overview of Quantum Sync features including sync, sharing, and security capabilities"}; #features -->
 ## Features
 
+[features]: #features "Features"
+
 $ProductName; $Version; includes a comprehensive set of features designed for both individual users and enterprise teams. This section provides detailed information about each major capability.
 
 <!-- multiline; marker:IndexMarker="encryption:end-to-end,synchronization:real-time,version history" -->

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/getting-started.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/getting-started.md
@@ -1,6 +1,8 @@
 <!-- markers:{"Keywords": "getting started, setup, installation, quickstart, prerequisites", "Description": "Step-by-step guide to installing and configuring Quantum Sync on your device", "IndexMarker": "installation,setup:initial"}; #getting-started -->
 ## Getting Started
 
+[getting-started]: #getting-started "Getting Started"
+
 This guide walks you through the initial setup of $ProductName; on your device. The entire process takes approximately five minutes.
 
 ### Prerequisites
@@ -23,7 +25,7 @@ Follow these steps to install and configure $ProductName;:
 
 4. **Select your sync folder** - Choose the local folder where $ProductName; will store synchronized files. The default location is your Documents folder.
 
-5. **Configure initial sync** - Select which existing cloud folders to sync to this device. You can change these settings later in [Settings](#settings).
+5. **Configure initial sync** - Select which existing cloud folders to sync to this device. You can change these settings later in [Settings][settings].
 
 > **Tip:** For the fastest initial sync, connect to a wired network if available. $ProductName; can download large file sets significantly faster over ethernet than Wi-Fi.
 
@@ -43,4 +45,4 @@ Watch our 3-minute setup video for a visual walkthrough of the installation proc
 
 ### Next Steps
 
-After installation, $ProductName; runs in the background and keeps your files synchronized automatically. To learn about available features, see [Features](#features). To customize sync behavior, see [Settings](#settings).
+After installation, $ProductName; runs in the background and keeps your files synchronized automatically. To learn about available features, see [Features][features]. To customize sync behavior, see [Settings][settings].

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/glossary.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/glossary.md
@@ -1,52 +1,86 @@
 <!-- markers:{"Keywords": "glossary, definitions, terms, terminology, reference", "Description": "Definitions of technical terms used throughout the Quantum Sync documentation"}; #glossary -->
 ## Glossary
 
+[glossary]: #glossary "Glossary"
+
 This glossary defines technical terms used throughout the $ProductName; documentation.
 
 <!-- style:Glossary Term ; #gloss-term-conflict -->
 ### Conflict:
 
+[gloss-term-conflict]: #gloss-term-conflict "Conflict"
+
 <!-- style:Glossary Def; #gloss-def-conflict -->
-A situation where the same file is modified on two or more devices before synchronization completes. $ProductName; resolves conflicts by keeping both versions and adding a timestamp to the filename of the secondary copy. See [Troubleshooting](#troubleshooting) for conflict resolution steps.
+A situation where the same file is modified on two or more devices before synchronization completes. $ProductName; resolves conflicts by keeping both versions and adding a timestamp to the filename of the secondary copy. See [Troubleshooting][troubleshooting] for conflict resolution steps.
+
+[gloss-def-conflict]: #gloss-def-conflict "Conflict definition"
 
 <!-- style:Glossary Term ; #gloss-term-delta-sync -->
 ### Delta Sync:
 
+[gloss-term-delta-sync]: #gloss-term-delta-sync "Delta Sync"
+
 <!-- style:Glossary Def; #gloss-def-delta-sync -->
 A synchronization technique that transmits only the changed portions of a file rather than the entire file. Delta sync significantly reduces bandwidth usage and sync time for large files with small modifications.
+
+[gloss-def-delta-sync]: #gloss-def-delta-sync "Delta Sync definition"
 
 <!-- style:Glossary Term ; marker:IndexMarker="encryption:definition" ; #gloss-term-encryption -->
 ### Encryption:
 
+[gloss-term-encryption]: #gloss-term-encryption "Encryption"
+
 <!-- style:Glossary Def; #gloss-def-encryption -->
-The process of encoding data so that only authorized parties can read it. $ProductName; uses AES-256 encryption for data at rest and TLS 1.3 for data in transit. See [Features](#features) for encryption details.
+The process of encoding data so that only authorized parties can read it. $ProductName; uses AES-256 encryption for data at rest and TLS 1.3 for data in transit. See [Features][features] for encryption details.
+
+[gloss-def-encryption]: #gloss-def-encryption "Encryption definition"
 
 <!-- style:Glossary Term ; #gloss-term-metered-connection -->
 ### Metered Connection:
 
+[gloss-term-metered-connection]: #gloss-term-metered-connection "Metered Connection"
+
 <!-- style:Glossary Def; #gloss-def-metered-connection -->
 A network connection with limited data allowance, such as cellular data or some Wi-Fi hotspots. $ProductName; can detect metered connections and pause automatic sync to avoid unexpected data charges.
+
+[gloss-def-metered-connection]: #gloss-def-metered-connection "Metered Connection definition"
 
 <!-- style:Glossary Term ; #gloss-term-selective-sync -->
 ### Selective Sync:
 
+[gloss-term-selective-sync]: #gloss-term-selective-sync "Selective Sync"
+
 <!-- style:Glossary Def; #gloss-def-selective-sync -->
-A feature that allows you to choose which folders sync to each device. Files in unselected folders remain in your cloud storage but do not consume local disk space. See [Sync Modes](#sync-modes) for configuration instructions.
+A feature that allows you to choose which folders sync to each device. Files in unselected folders remain in your cloud storage but do not consume local disk space. See [Sync Modes][sync-modes] for configuration instructions.
+
+[gloss-def-selective-sync]: #gloss-def-selective-sync "Selective Sync definition"
 
 <!-- style:Glossary Term ; #gloss-term-sync-folder -->
 ### Sync Folder:
 
+[gloss-term-sync-folder]: #gloss-term-sync-folder "Sync Folder"
+
 <!-- style:Glossary Def; #gloss-def-sync-folder -->
-The local directory where $ProductName; stores synchronized files. By default, this is located in your Documents folder. You can change the location in [Settings](#settings).
+The local directory where $ProductName; stores synchronized files. By default, this is located in your Documents folder. You can change the location in [Settings][settings].
+
+[gloss-def-sync-folder]: #gloss-def-sync-folder "Sync Folder definition"
 
 <!-- style:Glossary Term ; #gloss-term-version-history -->
 ### Version History:
 
+[gloss-term-version-history]: #gloss-term-version-history "Version History"
+
 <!-- style:Glossary Def; #gloss-def-version-history -->
-A record of previous versions of each file, maintained automatically by $ProductName;. You can restore or download any previous version within the retention period. See [Features](#features) for retention policy details.
+A record of previous versions of each file, maintained automatically by $ProductName;. You can restore or download any previous version within the retention period. See [Features][features] for retention policy details.
+
+[gloss-def-version-history]: #gloss-def-version-history "Version History definition"
 
 <!-- style:Glossary Term ; #gloss-term-zero-knowledge -->
 ### Zero-Knowledge Encryption:
 
+[gloss-term-zero-knowledge]: #gloss-term-zero-knowledge "Zero-Knowledge Encryption"
+
 <!-- style:Glossary Def; #gloss-def-zero-knowledge -->
 A security model where $ProductName; cannot decrypt your files, even if required by law enforcement. Only you hold the encryption keys. This feature is available as an optional setting for users who require maximum privacy.
+
+[gloss-def-zero-knowledge]: #gloss-def-zero-knowledge "Zero-Knowledge Encryption definition"

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/overview.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/overview.md
@@ -1,6 +1,8 @@
 <!-- markers:{"Keywords": "quantum sync, overview, cloud storage, file synchronization, benefits", "Description": "Learn what Quantum Sync is and why it's the ideal solution for cloud file synchronization", "IndexMarker": "cloud synchronization"}; #overview -->
 ## Overview
 
+[overview]: #overview "Overview"
+
 $ProductName; is a next-generation cloud synchronization service designed for teams and individuals who need reliable, secure file access across all their devices. Built with enterprise-grade security and consumer-friendly simplicity, $ProductName; bridges the gap between powerful functionality and ease of use.
 
 Whether you're a solo professional managing documents across laptops and tablets, or an enterprise IT administrator deploying to thousands of users, $ProductName; adapts to your workflow. Our intelligent sync engine detects changes in real-time and propagates them across your connected devices with minimal bandwidth usage.
@@ -21,4 +23,4 @@ $ProductName; uses a distributed architecture with regional data centers to ensu
 
 ![Quantum Sync Architecture](../images/quantum-sync-architecture.svg)
 
-For detailed information about specific features, see the [Features](#features) section.
+For detailed information about specific features, see the [Features][features] section.

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/settings.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/settings.md
@@ -1,6 +1,8 @@
 <!-- markers:{"Keywords": "settings, configuration, preferences, bandwidth, notifications, admin", "Description": "Configure Quantum Sync preferences including sync behavior, bandwidth limits, and notifications", "IndexMarker": "settings:configuring"}; #settings -->
 ## Settings
 
+[settings]: #settings "Settings"
+
 $ProductName; $Version; provides extensive configuration options to customize sync behavior for your environment. Access settings through the system tray icon or menu bar application.
 
 ### General Settings

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/sync-modes.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/sync-modes.md
@@ -1,6 +1,8 @@
 <!-- markers:{"Keywords": "sync modes, automatic, manual, selective, synchronization, bandwidth", "Description": "Choose the right synchronization mode for your workflow: automatic, manual, or selective sync", "IndexMarker": "synchronization:modes"}; #sync-modes -->
 ## Sync Modes
 
+[sync-modes]: #sync-modes "Sync Modes"
+
 $ProductName; offers three synchronization modes to accommodate different workflows and network conditions. You can switch between modes at any time through the application settings or system tray menu.
 
 ### Mode Comparison
@@ -35,4 +37,4 @@ Use selective sync to:
 
 To configure selective sync, open Settings and navigate to the **Selective Sync** tab. Check the folders you want to sync to this device.
 
-If you encounter sync issues after changing modes, see [Troubleshooting](#troubleshooting) for resolution steps.
+If you encounter sync issues after changing modes, see [Troubleshooting][troubleshooting] for resolution steps.

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/troubleshooting.md
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/Source Docs/topics/troubleshooting.md
@@ -1,12 +1,16 @@
 <!-- markers:{"Keywords": "troubleshooting, errors, sync issues, conflicts, diagnostics, support", "Description": "Resolve common Quantum Sync issues including sync failures, conflicts, and connection problems"}; #troubleshooting -->
 ## Troubleshooting
 
+[troubleshooting]: #troubleshooting "Troubleshooting"
+
 This section covers common issues and their solutions. If you cannot resolve a problem using these steps, contact support at $SupportEmail;.
 
 ### Common Issues
 
 <!-- style:Issue ; marker:IndexMarker="troubleshooting:files not syncing" ; #issue-files-not-syncing -->
 #### Files not syncing
+
+[issue-files-not-syncing]: #issue-files-not-syncing "Files not syncing"
 
 If files in your sync folder are not uploading or downloading:
 
@@ -18,7 +22,9 @@ If files in your sync folder are not uploading or downloading:
 <!-- style:Issue ; #issue-sync-conflicts -->
 #### Sync conflicts
 
-[Conflicts](#gloss-term-conflict) occur when the same file is modified on multiple devices before syncing completes. $ProductName; preserves both versions by renaming the conflicting copy with a timestamp suffix.
+[issue-sync-conflicts]: #issue-sync-conflicts "Sync conflicts"
+
+[Conflicts][gloss-term-conflict] occur when the same file is modified on multiple devices before syncing completes. $ProductName; preserves both versions by renaming the conflicting copy with a timestamp suffix.
 
 To resolve a conflict:
 
@@ -29,6 +35,8 @@ To resolve a conflict:
 
 <!-- style:Issue ; #issue-connection-errors -->
 #### Connection errors
+
+[issue-connection-errors]: #issue-connection-errors "Connection errors"
 
 If $ProductName; cannot connect to the server, check your network settings and firewall configuration. The application requires outbound access on ports 443 (HTTPS) and 8443 (WebSocket).
 
@@ -60,4 +68,4 @@ If you cannot resolve your issue using the steps above:
 - Post in the community forums at community.quantumsync.example
 - Contact support at $SupportEmail;
 
-For definitions of technical terms used in this section, see the [Glossary](#glossary).
+For definitions of technical terms used in this section, see the [Glossary][glossary].


### PR DESCRIPTION
## Summary

Apply the Markdown++ alias+slug+linkref **triple** to every aliased element in the trial source docs, and convert cross-reference links to the `[Text][slug]` form. 17 source doc files affected (10 Designer Trial, 7 Express Trial).

## Changes

### Triple coverage on every aliased element

The triple (directive, content, link reference definition) is now co-located on every heading or paragraph that carries a custom alias. The link reference definition appears on the line directly below the heading, separated by a single blank line.

Four previously uncovered referenceable elements also received an alias + triple:
- H1 in [title.md](latest/local-trial-projects/ePublisher%20Designer%20Projects/ePublisher%20Designer%20Trial/Source%20Docs/title.md) and [quantum-sync.md](latest/local-trial-projects/ePublisher%20Express%20Projects/ePublisher%20Express%20Trial%20Project/Source%20Docs/quantum-sync.md)
- `#### Real-Time Performance` and `#### Security Model` in [headings-and-text.md](latest/local-trial-projects/ePublisher%20Designer%20Projects/ePublisher%20Designer%20Trial/Source%20Docs/topics/headings-and-text.md)

### Cross-reference conversion to `[Text][slug]`

**Express Trial:** intra-file `[Text](#anchor)` converted to `[Text][slug]`. Slugs resolve via document-global scope after Phase 1 include assembly in `quantum-sync.md`. No new definitions needed.

**Designer Trial:** cross-file `[Text](file.md#anchor)` converted to `[Text][slug]`. Because each Designer Trial topic file is registered as a separate source document in the `.wep` project (no include assembly), outgoing-reference slug definitions are added to each file at the bottom — a CommonMark scope requirement, not a real-world maintenance pattern.

The cross-file slug-definition blocks in Designer Trial files are wrapped in an HTML comment that flags them as **pattern-file artifacts**, since this workflow is not how production source docs would typically be maintained.

### Validation

All 17 source doc files pass `validate-mdpp.py`:

```
$ python scripts/validate-mdpp.py <each source doc>
Valid: No issues found in ...
```

Grep against the old patterns returns zero matches:
- `]\([^)]*\.md#` — no remaining `[Text](file.md#anchor)` references
- `]\(#` — no remaining `[Text](#anchor)` references

## Related upstream issue

Filed [quadralay/markdown-plus-plus#103](https://github.com/quadralay/markdown-plus-plus/issues/103) to clarify in the skill docs that the triple requires adjacent placement — the placement rule is currently shown by example but never normatively stated.

## Test plan

- [ ] Open each updated source doc and confirm the directive, heading/paragraph, and `[slug]: ...` link reference appear as a single visually-contiguous unit
- [ ] Generate Designer Trial output (Reverb 2.0 target) and verify cross-file links from procedures, headings-and-text, content-islands, glossary, and expandable-sections resolve to the correct target file/anchor
- [ ] Generate Express Trial output (Reverb 2.0 target) and verify intra-doc links from getting-started, glossary, troubleshooting, overview, and sync-modes resolve to the correct anchors in the assembled document
- [ ] Confirm the pattern-file-artifact HTML comment is invisible in published output

🤖 Generated with [Claude Code](https://claude.com/claude-code)