### PR TITLE
Rebase trial projects to ePublisher 2026.1 platform

### DIFF
--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Formats/WebWorks Reverb 2.0/Pages/sass/skin.scss
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/Formats/WebWorks Reverb 2.0/Pages/sass/skin.scss
@@ -1059,6 +1059,15 @@ div.ww_skin_toolbar_logo {
 #menu_frame {
 }
 
+#menu_resize_handle {
+  background: transparent;
+  transition: background 0.15s;
+
+  &:hover, &.dragging, &:focus-visible {
+    background: $_layout_color_1;
+  }
+}
+
 .ww_skin_menu_nav {
 
 }
@@ -1124,39 +1133,34 @@ div.ww_skin_toolbar_logo {
 }
 
 .ww_skin_menu_nav_type_assistant {
-  // TODO: make these assistant SASS variables
-  border-style: $menu_nav_button_toc_border_style;
-  border-width: $menu_nav_button_toc_border_width;
-  border-color: $menu_nav_button_toc_border_color;
-  border-radius: $menu_nav_button_toc_border_radius;
+  border-style: $menu_nav_button_assistant_border_style;
+  border-width: $menu_nav_button_assistant_border_width;
+  border-color: $menu_nav_button_assistant_border_color;
+  border-radius: $menu_nav_button_assistant_border_radius;
 
   i:before {
     content: $menu_nav_button_assistant_icon;
   }
 
   &:hover, &:focus-within {
-    border-style: $menu_nav_button_toc_border_style_hover;
-    border-width: $menu_nav_button_toc_border_width_hover;
-    border-color: $menu_nav_button_toc_border_color_hover;
-    border-radius: $menu_nav_button_toc_border_radius_hover;
+    border-style: $menu_nav_button_assistant_border_style_hover;
+    border-width: $menu_nav_button_assistant_border_width_hover;
+    border-color: $menu_nav_button_assistant_border_color_hover;
+    border-radius: $menu_nav_button_assistant_border_radius_hover;
 
   }
 
   &:active {
-    border-style: $menu_nav_button_toc_border_style_click;
-    border-width: $menu_nav_button_toc_border_width_click;
-    border-color: $menu_nav_button_toc_border_color_click;
-    border-radius: $menu_nav_button_toc_border_radius_click;
+    border-style: $menu_nav_button_assistant_border_style_click;
+    border-width: $menu_nav_button_assistant_border_width_click;
+    border-color: $menu_nav_button_assistant_border_color_click;
+    border-radius: $menu_nav_button_assistant_border_radius_click;
 
   }
 }
 
 .ww_skin_menu_assistant {
   font-size: $menu_nav_buttons_icon_size;
-  display: table-cell;
-  vertical-align: middle;
-  width: $menu_nav_buttons_width_calculated;
-  height: $menu_nav_buttons_height_calculated;
 }
 
 .ww_skin_menu_nav_type_toc {
@@ -1186,18 +1190,10 @@ div.ww_skin_toolbar_logo {
 
 .ww_skin_menu_toc {
   font-size: $menu_nav_buttons_icon_size;
-  display: table-cell;
-  vertical-align: middle;
-  width: $menu_nav_buttons_width_calculated;
-  height: $menu_nav_buttons_height_calculated;
 }
 
 .ww_skin_menu_index {
   font-size: $menu_nav_buttons_icon_size;
-  display: table-cell;
-  vertical-align: middle;
-  width: $menu_nav_buttons_width_calculated;
-  height: $menu_nav_buttons_height_calculated;
 }
 
 .ww_skin_menu_nav_type_index {
@@ -2223,6 +2219,145 @@ div#disqus_thread {
   font-weight: bold;
   color: $no_javascript_text_color;
   background: $no_javascript_background_color;
+}
+
+/* Assistant Chat */
+
+// Assistant Role Label
+.ww_skin_assistant_role_label {
+  font-family: $assistant_font;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.ww_skin_assistant_message .ww_skin_assistant_message_content_container {
+  border-left: 2px solid $assistant_primary_color;
+}
+
+.ww_skin_assistant_message .ww_skin_assistant_role_label {
+  color: $assistant_primary_color;
+}
+
+.ww_skin_assistant_user_message .ww_skin_assistant_role_label {
+  color: $assistant_secondary_text_color;
+}
+
+// Assistant User Bubble
+.ww_skin_assistant_user_bubble {
+  background-color: $assistant_user_bubble_background_color;
+  color: $assistant_user_bubble_text_color;
+  border-radius: 0.875rem 0.875rem 0.1875rem 0.875rem;
+  line-height: 1.45;
+}
+
+// Assistant Avatar
+.ww_skin_assistant_avatar {
+  border-radius: $assistant_border_radius_round;
+  background-color: $assistant_avatar_background_color;
+
+  i {
+    color: $assistant_avatar_icon_color;
+    font-size: 0.875rem;
+
+    &:before {
+      content: $assistant_avatar_icon;
+    }
+  }
+}
+
+.ww_skin_assistant_welcome_screen .ww_skin_assistant_avatar i {
+  font-size: 1.5rem;
+}
+
+.ww_skin_assistant_info .ww_skin_assistant_avatar i {
+  font-size: 1.25rem;
+}
+
+// Assistant Bubble
+.ww_skin_assistant_bubble {
+  background-color: transparent;
+  border-radius: 0;
+  color: $assistant_bubble_text_color;
+  line-height: 1.55;
+
+  a {
+    color: $assistant_bubble_link_color;
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+    text-decoration-thickness: 1px;
+    transition: text-decoration-thickness 120ms ease-out;
+  }
+
+  a:hover {
+    text-decoration-thickness: 2px;
+  }
+
+  ul { list-style-type: disc; }
+  ul ul { list-style-type: circle; }
+  ul ul ul { list-style-type: square; }
+
+  ol { list-style-type: decimal; }
+  ol ol { list-style-type: lower-alpha; }
+  ol ol ol { list-style-type: lower-roman; }
+
+  code {
+    font-family: monospace;
+    font-size: 0.875em;
+    background-color: $assistant_code_background_color;
+    border-radius: 0.1875rem;
+  }
+
+  pre {
+    background-color: $assistant_pre_background_color;
+    border: 1px solid $assistant_table_border_color;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
+
+  pre code {
+    background-color: transparent;
+    font-size: inherit;
+  }
+
+  table {
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  th,
+  td {
+    border: 1px solid $assistant_table_border_color;
+    text-align: left;
+  }
+
+  th {
+    background-color: $assistant_table_header_background_color;
+    font-weight: 600;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    line-height: 1.25;
+    font-weight: 600;
+  }
+
+  h1 { font-size: 1.125rem; }
+  h2 { font-size: 1rem; }
+  h3 { font-size: 0.9375rem; }
+  h4, h5, h6 { font-size: 0.875rem; }
+
+  blockquote {
+    border-left: 2px solid $assistant_table_border_color;
+    color: $assistant_secondary_text_color;
+  }
+
+  hr {
+    border: 0;
+    border-top: 1px solid $assistant_table_border_color;
+  }
 }
 
 @import "custom-skin"; // WEBWORKS

--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/ePublisher Designer Trial.wep
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/ePublisher Designer Trial.wep
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Version="1.1.2.0" ProjectID="hMDzxVACF5I" ChangeID="l03_MbkPkBA" RuntimeVersion="2025.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
+<Project Version="1.1.2.0" ProjectID="hMDzxVACF5I" ChangeID="JGPEqmOEyUU" RuntimeVersion="2026.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
   <Formats>
     <Format TargetName="Web Help" Name="WebWorks Reverb 2.0" Type="Application" TargetID="Lf3DjZlhl_A">
       <OutputDirectory>Output\Web Help</OutputDirectory>
@@ -210,7 +210,6 @@
   </GlobalConfiguration>
   <FormatConfigurations>
     <FormatConfiguration TargetID="Lf3DjZlhl_A" ChangeID="W13XsKKBzKA">
-      <Rules Type="Paragraph" ChangeID="" />
       <Conditions Expression="" UseClassicConditions="False" UseDocumentExpression="True">
         <Condition Name="advanced" Value="Visible" Passthrough="False" UseDocumentValue="False" />
         <Condition Name="online_only" Value="Visible" Passthrough="False" UseDocumentValue="False" />
@@ -222,7 +221,6 @@
         <Variable Name="Version" Value="2.0" UseDocumentValue="False" />
         <Variable Name="ProductGuideTitle" Value="User Manual" UseDocumentValue="False" />
       </Variables>
-      <XRefFormatSet />
       <FormatSettings>
         <FormatSetting Name="company-copyright" Value="© 2026 Quantum Sync" />
         <FormatSetting Name="company-email" Value="info@quantum-sync.com" />
@@ -293,5 +291,7 @@
       <AdapterConfigurationEntry Name="dita-ot-version" Value="3.7.4" />
     </AdapterConfiguration>
   </AdapterConfigurations>
-  <ProjectSettings />
+  <ProjectSettings>
+    <ProjectSetting Name="UpdateUniqueIDs" Value="True" />
+  </ProjectSettings>
 </Project>

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/ePublisher Express Trial Project.wrp
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/ePublisher Express Trial Project.wrp
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Version="1.1.2.0" ProjectID="P03m6LWnOVw" ChangeID="88R2JBvh0_w" RuntimeVersion="2025.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
+<Project Version="1.1.2.0" ProjectID="P03m6LWnOVw" ChangeID="pqbiw9XVE2k" RuntimeVersion="2026.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
   <Origin>
-    <Path Checksum="F7A152A5FB8C11BBD7B3D34834E49E209C5E428F" LastModified="2026-03-12T01:37:15.9748364Z">..\..\ePublisher Stationery\ePublisher Express Trial Stationery\ePublisher Express Trial Stationery.wxsp</Path>
+    <Path Checksum="AEC1CDF752B1BD290209ECB819255DE44669549D" LastModified="2026-05-19T20:40:38.7887619Z">..\..\ePublisher Stationery\ePublisher Express Trial Stationery\ePublisher Express Trial Stationery.wxsp</Path>
   </Origin>
   <Formats>
     <Format TargetName="Web Help" Name="WebWorks Reverb 2.0" Type="Application" TargetID="Lf3DjZlhl_A">

--- a/latest/local-trial-projects/ePublisher Stationery/ePublisher Express Trial Stationery/ePublisher Express Trial Stationery.wxsp
+++ b/latest/local-trial-projects/ePublisher Stationery/ePublisher Express Trial Stationery/ePublisher Express Trial Stationery.wxsp
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Version="1.1.2.0" RuntimeVersion="2025.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
+<Project Version="1.1.2.0" RuntimeVersion="2026.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
   <Formats>
     <Format TargetName="Web Help" Name="WebWorks Reverb 2.0" Type="Application" TargetID="Lf3DjZlhl_A">
       <OutputDirectory>Output\Web Help</OutputDirectory>


### PR DESCRIPTION
## Summary

Rebase the Designer Trial, Express Trial, and Express Stationery onto the ePublisher 2026.1 platform. Brings the trial projects current with the upcoming release and adds Reverb 2.0 2026.1 skin support for the new Assistant Chat feature.

## Changes

### Runtime version bump (2025.1 → 2026.1)

- [Designer Trial.wep](latest/local-trial-projects/ePublisher%20Designer%20Projects/ePublisher%20Designer%20Trial/ePublisher%20Designer%20Trial.wep)
- [Express Trial.wrp](latest/local-trial-projects/ePublisher%20Express%20Projects/ePublisher%20Express%20Trial%20Project/ePublisher%20Express%20Trial%20Project.wrp)
- [Express Trial Stationery.wxsp](latest/local-trial-projects/ePublisher%20Stationery/ePublisher%20Express%20Trial%20Stationery/ePublisher%20Express%20Trial%20Stationery.wxsp)

The Express Trial Stationery checksum/timestamp updated in the `.wrp` reflects a fresh Stationery application.

### Reverb 2.0 skin updates ([skin.scss](latest/local-trial-projects/ePublisher%20Designer%20Projects/ePublisher%20Designer%20Trial/Formats/WebWorks%20Reverb%202.0/Pages/sass/skin.scss))

- Add `#menu_resize_handle` styling with hover/dragging/focus-visible states
- Wire `.ww_skin_menu_nav_type_assistant` to its own `$menu_nav_button_assistant_*` variables (was borrowing the TOC button's variables — TODO comment removed)
- Drop redundant `display: table-cell; vertical-align: middle; width; height` declarations from `.ww_skin_menu_assistant`, `.ww_skin_menu_toc`, and `.ww_skin_menu_index`
- Add the full Assistant Chat block: role labels, user bubble (rounded with tail), avatar (round, themed background/icon), bot bubble with link/list/code/pre/table styling

### Project file side effects

The `.wep` re-save by Designer 2026.1 added `<ProjectSetting Name="UpdateUniqueIDs" Value="True" />` and dropped two empty XML elements (`<Rules Type="Paragraph">` and `<XRefFormatSet />`).

## Test plan

- [ ] Open both projects in ePublisher 2026.1 Designer and confirm clean load (no migration prompts)
- [ ] Generate the Web Help target on the Designer Trial; confirm the new menu resize handle and Assistant button render with the new styling
- [ ] Generate the Web Help target on the Express Trial against the re-applied Stationery; confirm output matches expectations
- [ ] Spot-check Assistant Chat rendering if a chat-enabled output is available (role labels, user bubble shape, avatar, bot bubble link/list/code/pre/table styling)
- [ ] Verify PDF (XSL-FO) targets still generate clean on both projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)