### PR TITLE
Enable source-id landmark format on trial projects

### DIFF
--- a/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/ePublisher Designer Trial.wep
+++ b/latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/ePublisher Designer Trial.wep
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Version="1.1.2.0" ProjectID="hMDzxVACF5I" ChangeID="JGPEqmOEyUU" RuntimeVersion="2026.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
+<Project Version="1.1.2.0" ProjectID="hMDzxVACF5I" ChangeID="a-BvQKIvg6c" RuntimeVersion="2026.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
   <Formats>
     <Format TargetName="Web Help" Name="WebWorks Reverb 2.0" Type="Application" TargetID="Lf3DjZlhl_A">
       <OutputDirectory>Output\Web Help</OutputDirectory>
@@ -20,9 +20,13 @@
       <Document Type="normal" Included="true" DocumentID="gOZ8DQsVw7C" ChangeID="" Path="Source Docs\topics\glossary.md" />
     </Group>
   </Groups>
-  <GlobalConfiguration ChangeID="wWx_Pl_wWm0">
+  <GlobalConfiguration ChangeID="aJl3ofWjfsM">
     <Rules Type="Paragraph" Default="{WWDefaultRule}" ChangeID="">
-      <Rule Key="{WWDefaultRule}" ChangeID="DdSLs2ByvOc" />
+      <Rule Key="{WWDefaultRule}" ChangeID="bz464kqN2Bc">
+        <Options>
+          <Option Name="landmark-id-format" Value="source-id" Source="Explicit" />
+        </Options>
+      </Rule>
       <Rule Key="Blockquote" />
       <Rule Key="Blockquote Paragraph" />
       <Rule Key="Code Fence" />
@@ -210,6 +214,7 @@
   </GlobalConfiguration>
   <FormatConfigurations>
     <FormatConfiguration TargetID="Lf3DjZlhl_A" ChangeID="W13XsKKBzKA">
+      <Rules Type="Paragraph" ChangeID="" />
       <Conditions Expression="" UseClassicConditions="False" UseDocumentExpression="True">
         <Condition Name="advanced" Value="Visible" Passthrough="False" UseDocumentValue="False" />
         <Condition Name="online_only" Value="Visible" Passthrough="False" UseDocumentValue="False" />

--- a/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/ePublisher Express Trial Project.wrp
+++ b/latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/ePublisher Express Trial Project.wrp
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Version="1.1.2.0" ProjectID="P03m6LWnOVw" ChangeID="pqbiw9XVE2k" RuntimeVersion="2026.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
+<Project Version="1.1.2.0" ProjectID="P03m6LWnOVw" ChangeID="PJbu_eITq9c" RuntimeVersion="2026.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
   <Origin>
-    <Path Checksum="AEC1CDF752B1BD290209ECB819255DE44669549D" LastModified="2026-05-19T20:40:38.7887619Z">..\..\ePublisher Stationery\ePublisher Express Trial Stationery\ePublisher Express Trial Stationery.wxsp</Path>
+    <Path Checksum="BFF3222231F246698B6E8A04B8D4E74DA3124D48" LastModified="2026-05-19T21:43:58.1925749Z">..\..\ePublisher Stationery\ePublisher Express Trial Stationery\ePublisher Express Trial Stationery.wxsp</Path>
   </Origin>
   <Formats>
     <Format TargetName="Web Help" Name="WebWorks Reverb 2.0" Type="Application" TargetID="Lf3DjZlhl_A">
@@ -14,9 +14,13 @@
   <Groups>
     <Group Name="Help" Type="normal" Included="true" GroupID="2dneiXg3AfI" ChangeID="1H0d0XMlE24" />
   </Groups>
-  <GlobalConfiguration ChangeID="1G71rlEycUw">
+  <GlobalConfiguration ChangeID="kUovk04jwto">
     <Rules Type="Paragraph" Default="{WWDefaultRule}" ChangeID="">
-      <Rule Key="{WWDefaultRule}" />
+      <Rule Key="{WWDefaultRule}" ChangeID="TyK6PGPkpu0">
+        <Options>
+          <Option Name="landmark-id-format" Value="source-id" Source="Explicit" />
+        </Options>
+      </Rule>
       <Rule Key="Blockquote" />
       <Rule Key="Blockquote Paragraph" />
       <Rule Key="Code Fence" />

--- a/latest/local-trial-projects/ePublisher Stationery/ePublisher Express Trial Stationery/ePublisher Express Trial Stationery.wxsp
+++ b/latest/local-trial-projects/ePublisher Stationery/ePublisher Express Trial Stationery/ePublisher Express Trial Stationery.wxsp
@@ -10,7 +10,11 @@
   </Formats>
   <GlobalConfiguration>
     <Rules Type="Paragraph" Default="{WWDefaultRule}" ChangeID="">
-      <Rule Key="{WWDefaultRule}" />
+      <Rule Key="{WWDefaultRule}">
+        <Options>
+          <Option Name="landmark-id-format" Value="source-id" Source="Explicit" />
+        </Options>
+      </Rule>
       <Rule Key="Blockquote" />
       <Rule Key="Blockquote Paragraph" />
       <Rule Key="Code Fence" />
@@ -198,6 +202,7 @@
   </GlobalConfiguration>
   <FormatConfigurations>
     <FormatConfiguration TargetID="Lf3DjZlhl_A">
+      <Rules Type="Paragraph" ChangeID="" />
       <Conditions Expression="" UseClassicConditions="False" UseDocumentExpression="True">
         <Condition Name="advanced" Value="Visible" Passthrough="False" UseDocumentValue="False" />
         <Condition Name="online_only" Value="Visible" Passthrough="False" UseDocumentValue="False" />
@@ -209,7 +214,6 @@
         <Variable Name="Version" Value="2.0" UseDocumentValue="False" />
         <Variable Name="ProductGuideTitle" Value="User Manual" UseDocumentValue="False" />
       </Variables>
-      <XRefFormatSet />
       <FormatSettings>
         <FormatSetting Name="company-copyright" Value="© 2026 Quantum Sync" />
         <FormatSetting Name="company-email" Value="info@quantum-sync.com" />


### PR DESCRIPTION
## Summary

Switch all three trial-project files (`.wep`, `.wrp`, `.wxsp`) to emit source-derived IDs as the URL fragment identifier for every landmark. Pairs with the Markdown++ triple-pattern work in #17 — the triples carry the slugs in the source, this PR carries them through into the published HTML.

## Change

On the `{WWDefaultRule}` paragraph rule in each project, set:

```xml
<Rule Key="{WWDefaultRule}">
  <Options>
    <Option Name="landmark-id-format" Value="source-id" Source="Explicit" />
  </Options>
</Rule>
```

| File | Effect |
|------|--------|
| `ePublisher Designer Trial.wep` | Source IDs in Designer Trial output |
| `ePublisher Express Trial Project.wrp` | Source IDs in Express Trial output |
| `ePublisher Express Trial Stationery.wxsp` | Default for any future project applied from this Stationery |

The `.wrp` Origin checksum/timestamp also updates from the fresh Stationery application.

## Why this matters

Before: a Markdown++ custom alias like `#settings` would be replaced by an auto-generated landmark ID in the published HTML (e.g., `landmark-23`). Author-visible links like `[Settings][settings]` would resolve in source but lose their semantic anchor in the output URL.

After: the published anchor matches the source ID — `Settings.html#settings`, `procedures.html#installation`, etc. The triple pattern's slug is preserved end-to-end, deep-links survive heading rewordings, and external URLs remain stable as long as authors keep the custom alias stable.

## Test plan

- [ ] Generate the Web Help target on the Designer Trial; spot-check rendered output anchors in `procedures.html`, `conditions-and-variables.html`, `glossary.html` — every Markdown++ custom alias should appear as the HTML fragment ID on its target element
- [ ] Generate the Web Help target on the Express Trial; same spot-check across `quantum-sync.html`-rooted output
- [ ] Verify intra-document links (`[Settings][settings]`) and cross-document links (`conditions-and-variables.html#settings`) resolve to the correct sections in the rendered output
- [ ] Confirm the PDF (XSL-FO) target still generates clean on both projects
- [ ] No new warnings in `generate.log` related to ID generation (the existing duplicate-alias warnings are tracked in Trac #2756)

🤖 Generated with [Claude Code](https://claude.com/claude-code)