### PR TITLE
Update webworks-claude-skills references to webworks-agent-skills

### DIFF
--- a/.claude/commands/publish-jobs.md
+++ b/.claude/commands/publish-jobs.md
@@ -30,7 +30,7 @@ Publish all AutoMap job files in the `automap-jobs/` directory.
       - `DEPLOY_PATH` = `$AUTOMAP_DEPLOY_PATH/$DEPLOY_FOLDER`
 
    d. **Execute the AutoMap build:**
-      Invoke the `webworks-claude-skills:automap` skill with:
+      Invoke the `webworks-agent-skills:automap` skill with:
       - Job file: `automap-jobs/<JOB_FILE>`
       - Deploy path: `<DEPLOY_PATH>`
       - Flags: `-l` (clean deploy folder before deploying)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,8 +6,8 @@
   },
   "permissions": {
     "allow": [
-      "Skill(webworks-claude-skills:automap)",
-      "Skill(webworks-claude-skills:automap:*)"
+      "Skill(webworks-agent-skills:automap)",
+      "Skill(webworks-agent-skills:automap:*)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Source documents are authored in [Markdown++](https://static.webworks.com/docs/e
 ## Resources
 
 - [ePublisher Documentation](https://static.webworks.com/docs/epublisher/latest/help/)
-- [WebWorks Claude Skills](https://github.com/quadralay/webworks-claude-skills) - AI skills for ePublisher
+- [WebWorks Agent Skills](https://github.com/quadralay/webworks-agent-skills) - AI agent skills for ePublisher
 - [WebWorks](https://www.webworks.com/)
 
 ## License


### PR DESCRIPTION
## Summary

The [`quadralay/webworks-claude-skills`](https://github.com/quadralay/webworks-claude-skills) repo is being renamed to [`quadralay/webworks-agent-skills`](https://github.com/quadralay/webworks-agent-skills) per the trademark/branding analysis in [quadralay/webworks-brain#20](https://github.com/quadralay/webworks-brain/pull/20). See the main rename PR: [quadralay/webworks-claude-skills#97](https://github.com/quadralay/webworks-claude-skills/pull/97).

This PR updates this repo's references to use the new plugin name and skill namespace.

## Changes

- `README.md` — "WebWorks Claude Skills" link text and URL
- `.claude/commands/publish-jobs.md` — skill invocation `webworks-claude-skills:automap` → `webworks-agent-skills:automap`
- `.claude/settings.local.json` — permission allowlist entries

## Merge ordering

**Do not merge until** the upstream rename PR ([quadralay/webworks-claude-skills#97](https://github.com/quadralay/webworks-claude-skills/pull/97)) is merged and the GitHub repo rename is complete. Until then, the new namespace `webworks-agent-skills:*` does not resolve and the `/publish-jobs` command will fail.

## Test plan

- [ ] After merging the upstream rename, install `webworks-agent-skills` plugin in a Claude Code instance
- [ ] Run `/publish-jobs` against this repo's `automap-jobs/` and verify it executes without permission prompts and completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)