### PR TITLE
Document trial project maintenance and release migration workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,11 @@ Default vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-f
 ### Domain docs
 
 Single-context — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Trial project workflow
+
+The clone is the source of truth for all trial-project content. Open ePublisher Designer directly against the `.wep`/`.wrp`/`.wxsp` files under `latest/local-trial-projects/` — do not use the OneDrive Documents copies. Refresh the dev repo's `.wez` packages with the `/package-trials` slash command (purge `Logs/`, `Output/`, `Reports/` first). See `docs/agents/trial-project-workflow.md`.
+
+### Release migration
+
+When ePublisher ships a new runtime release (e.g., 2025.1 → 2026.1), migrate the Designer project, reconfigure new Target Settings, save-as-Stationery to overwrite the `.wxsp`, then sync the Express `.wrp` to the updated Stationery. See `docs/agents/release-migration.md` for the step-by-step procedure and per-release notes.

--- a/docs/agents/release-migration.md
+++ b/docs/agents/release-migration.md
@@ -1,0 +1,44 @@
+# Release migration workflow
+
+When ePublisher ships a new runtime release (e.g., 2025.1 → 2026.1), the trial projects need to be migrated onto the new runtime and reconfigured for any new format-level settings. Runs once per release cycle, on top of the day-to-day maintenance flow in `docs/agents/trial-project-workflow.md`.
+
+## Prerequisites
+
+- ePublisher Designer installed at the new release version.
+- Clone up to date on `master`.
+- No pending uncommitted changes under `latest/local-trial-projects/` — commit or stash anything in flight first. Migration edits should not mix with unrelated work.
+
+## Steps
+
+### 1. Migrate the Designer project (`.wep`)
+
+1. Open ePublisher Designer at the new release version.
+2. File → Open Project → `latest\local-trial-projects\ePublisher Designer Projects\ePublisher Designer Trial\ePublisher Designer Trial.wep`.
+3. Accept the migration prompt to bring the project onto the new runtime.
+4. Walk through the project's overrides (paragraph styles, character styles, table styles, image handling, condition rules, variables, format settings). Confirm each survived migration. Where Designer has changed a default, decide per override whether to keep the existing value or accept the new default.
+5. Under Format Settings for each target, review any Target Settings newly introduced in this release. Set each explicitly to the intended value so the trial anchors on that value rather than following whatever default a future release ships. See the release-specific notes below for known items.
+
+### 2. Save the Stationery (`.wxsp`)
+
+1. File → Save as Stationery.
+2. Overwrite `latest\local-trial-projects\ePublisher Stationery\ePublisher Express Trial Stationery\ePublisher Express Trial Stationery.wxsp`.
+3. Confirm the overwrite when prompted.
+
+### 3. Sync the Express project (`.wrp`)
+
+1. File → Open Project → `latest\local-trial-projects\ePublisher Express Projects\ePublisher Express Trial Project\ePublisher Express Trial Project.wrp`.
+2. Designer detects the newer Stationery. Synchronize the project with it.
+3. Save the project.
+
+### 4. Package and commit
+
+- Refresh the `.wez` archives per `docs/agents/trial-project-workflow.md` § "Refreshing `.wez` packages in the dev repo", then commit them to SVN.
+- Open a PR against `master` bundling the `.wep`, `.wxsp`, `.wrp` changes plus any migration-triggered SCSS or asset updates.
+
+## Release-specific notes
+
+Track release-specific migration decisions here so they do not get lost.
+
+### 2026.1
+
+- **Disable "Use first document instead of splash page"** — this Target Setting was newly introduced in 2026.1. The trial projects should keep the existing splash-page behavior, so set this explicitly to disabled in each Target's Format Settings before saving the Stationery.

--- a/docs/agents/trial-project-workflow.md
+++ b/docs/agents/trial-project-workflow.md
@@ -1,0 +1,82 @@
+# Trial project workflow
+
+Where the trial projects live, how to edit them, and how to refresh the `.wez` packages shipped in the ePublisher dev repo.
+
+## Source of truth
+
+This git clone is the source of truth for all trial-project content:
+
+- Designer Trial: `latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial/`
+- Express Trial: `latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project/`
+- Express Stationery: `latest/local-trial-projects/ePublisher Stationery/ePublisher Express Trial Stationery/`
+
+Historical copies at `C:\Users\mcdow\OneDrive\Documents\ePublisher *` predate this convention. Do not edit them — they will drift silently and cause sync headaches later. Archive or delete them at your leisure.
+
+## Editing projects
+
+**In ePublisher Designer** (for project settings, style rules, format configurations, source-doc registration):
+
+1. Open Designer.
+2. File → Open Project. Navigate to the clone path and open the `.wep` / `.wrp` file directly (e.g., `C:\Projects\epublisher-express-trial\latest\local-trial-projects\ePublisher Designer Projects\ePublisher Designer Trial\ePublisher Designer Trial.wep`).
+3. Designer will remember the recent path on subsequent opens.
+4. Make edits, save in Designer.
+
+**In your editor of choice** (for Markdown++ source content under `Source Docs/`, SCSS under `Formats/`):
+
+Edit files directly in the clone. If Designer is open on the project, close and reopen it to pick up file-content changes.
+
+Commit source changes to git and open a PR per the usual repo conventions.
+
+## Refreshing `.wez` packages in the dev repo
+
+The ePublisher dev repo at `%EPUBLISHER_DEV_PATH%` (typically `C:\Repo\ePublisher_debug\trunk`) ships three `.wez` archives that become the sample projects users see in the installed trial:
+
+| Archive | Destination under `%SVN_LOCAL_PATH%\` |
+|---------|----------------------------------------|
+| `Exp_Design.wez` | `products\ePublisher\Evaluation\` |
+| `Exp_ePub.wez` | `products\Express\Evaluation\` |
+| `Exp_Stationery.wez` | `products\Express\Evaluation\` |
+
+To refresh them:
+
+1. **Purge generated dirs.** ePublisher writes `Logs/`, `Output/`, and `Reports/` into each project folder when it runs. These are gitignored and must not ship inside the `.wez`. Delete them from each of the three clone project folders before packaging:
+
+   ```bash
+   for p in \
+     "latest/local-trial-projects/ePublisher Designer Projects/ePublisher Designer Trial" \
+     "latest/local-trial-projects/ePublisher Express Projects/ePublisher Express Trial Project" \
+     "latest/local-trial-projects/ePublisher Stationery/ePublisher Express Trial Stationery"; do
+     rm -rf "$p/Logs" "$p/Output" "$p/Reports"
+   done
+   ```
+
+2. **Run `/package-trials`.** This zips each project folder (contents at archive root) and writes the `.wez` directly to the three SVN evaluation directories. See `.claude/commands/package-trials.md` for the full mechanics.
+
+3. **Sanity-check sizes.** Rough expected sizes:
+   - `Exp_Design.wez` — ~1.6 MB (customizations + source docs only)
+   - `Exp_ePub.wez` — ~3.0 MB (full baseline + source docs)
+   - `Exp_Stationery.wez` — ~3.0 MB (full baseline)
+
+   A meaningfully larger archive usually means generated dirs crept back in — re-check step 1.
+
+4. **Commit to SVN.** Commit the updated `.wez` files in the dev repo (SmartSVN / TortoiseSVN / `svn commit`). Include a short message noting what changed in the trial content and which trial-repo PR it corresponds to.
+
+## Baseline vs. source content
+
+The `.gitignore` deliberately excludes baseline content that Designer regenerates:
+
+- **Designer Trial** — everything under it is tracked (source + customizations)
+- **Express Trial** — only `.wrp` and `Source Docs/` are tracked; `Files/`, `Formats/`, `stationery.manifest` are ignored (they come from the Stationery)
+- **Express Stationery** — only `.wxsp` is tracked; `Files/`, `Formats/`, `Settings/`, `.manifest` are ignored (they come from adapter baselines)
+
+The ignored files still have to exist on disk for Designer to open the projects and for `/package-trials` to produce complete `.wez` archives. If any of them go missing, reopen the project in Designer and let it re-apply the Stationery or reset the baseline.
+
+## When to package vs. when to commit
+
+Every source-doc or project-file change goes to git (PR against `master`).
+
+`.wez` packages get refreshed for the dev repo whenever you want that change to reach the installed trial — typically once per release cycle, or when a user-facing change to a trial project needs to be shipped in the next ePublisher build. The `.wez` files themselves live in SVN, not in this git repo.
+
+## Related workflows
+
+- **Release migration** — When ePublisher ships a new runtime release, follow `docs/agents/release-migration.md` to migrate `.wep`, save the updated Stationery, and sync the Express `.wrp`. Refresh the `.wez` archives per this doc's packaging steps once the migration is complete.


### PR DESCRIPTION
## Summary

Two workflows that had no home in the repo before now have one:

- **[docs/agents/trial-project-workflow.md](docs/agents/trial-project-workflow.md)** -- how the trial projects are maintained: the clone is source of truth, ePublisher Designer opens `.wep`/`.wrp`/`.wxsp` directly from the clone paths (not the OneDrive Documents copies), and the dev repo's `.wez` archives get refreshed with `/package-trials` after purging `Logs/`/`Output/`/`Reports/`.
- **[docs/agents/release-migration.md](docs/agents/release-migration.md)** -- the per-release procedure to migrate the Designer project onto a new runtime, save-as-Stationery to overwrite the `.wxsp`, then sync the Express `.wrp` to the updated Stationery. Includes a "Release-specific notes" section seeded with the 2026.1 decision to disable **Use first document instead of splash page**.

[CLAUDE.md](CLAUDE.md) picks up cross-references to both docs under "Agent skills" so future sessions find them without spelunking.

## Why now

Earlier this cycle we spent time reconstructing "how are the trial projects supposed to be maintained?" from git log and file layouts. Nothing was written down, so the OneDrive-vs-clone question and the release-migration steps had to be re-derived. This PR removes that recurring cost.

## Test plan

- [x] Both docs render cleanly (headings, tables, code blocks)
- [x] Cross-references resolve (CLAUDE.md points at both new docs; the two docs point at each other where relevant)
- [x] Instructions match what the workflow tool (`/package-trials`) actually does today
- [x] 2026.1 release-specific note is captured under "Release-specific notes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)