### PR TITLE
Point trial AutoMap jobs at 2026.1 design.wep with S3 destinations

### DIFF
--- a/automap-jobs/trial-designer.waj
+++ b/automap-jobs/trial-designer.waj
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Job name="trial-designer" version="1.0">
-  <Project path="C:\Projects\epublisher-docs-publish\webworks\ePublisher Stationery 2025.1\ePublisher Stationery 2025.1.wxsp" />
+  <Project path="C:\Projects\epublisher-docs\webworks\design\design.wep" />
   <Files>
     <Group name="Designer Trial Guide">
       <Document path="..\latest\online-trial-guides\designer-trial\designer-trial-guide.md" />
     </Group>
   </Files>
   <Targets>
-    <Target name="Online Guides" format="WebWorks Reverb 2.0" formatType="Application" build="True" deployTarget="" cleanOutput="True">
+    <Target name="Online Guides" format="WebWorks Reverb 2.0" formatType="Application" build="True" destination="DocsDesignerTrial" cleanOutput="True">
       <Conditions Expression="" UseClassicConditions="False" UseDocumentExpression="True">
         <Condition name="AutomapOnly" value="True" Passthrough="False" UseDocumentValue="False" />
         <Condition name="DesignerOnly" value="True" Passthrough="False" UseDocumentValue="False" />

--- a/automap-jobs/trial-express.waj
+++ b/automap-jobs/trial-express.waj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Job name="trial-express" version="1.0">
-  <Project path="C:\Projects\epublisher-docs-publish\webworks\ePublisher Stationery 2025.1\ePublisher Stationery 2025.1.wxsp" />
+  <Project path="C:\Projects\epublisher-docs\webworks\design\design.wep" />
   <Files>
     <Group name="Express Trial Guide">
       <Document path="..\latest\online-trial-guides\express-trial\express-trial-guide.md" />
     </Group>
   </Files>
   <Targets>
-    <Target name="Online Guides" format="WebWorks Reverb 2.0" formatType="Application" build="True" deployTarget="" cleanOutput="True">
+    <Target name="Online Guides" format="WebWorks Reverb 2.0" formatType="Application" build="True" destination="DocsExpressTrial" cleanOutput="True">
       <Conditions Expression="" UseClassicConditions="False" UseDocumentExpression="True">
         <Condition name="AutomapOnly" value="True" Passthrough="False" UseDocumentValue="False" />
         <Condition name="DesignerOnly" value="True" Passthrough="False" UseDocumentValue="False" />


### PR DESCRIPTION
## Summary

Two 2026.1 GA updates to the online-guide AutoMap job files under [automap-jobs/](automap-jobs/):

### Project path swap

Both jobs now use the local Designer project as the origin instead of the older 2025.1 Stationery:

\`\`\`
Was: C:\Projects\epublisher-docs-publish\webworks\ePublisher Stationery 2025.1\ePublisher Stationery 2025.1.wxsp
Now: C:\Projects\epublisher-docs\webworks\design\design.wep
\`\`\`

Opened as a Designer project (\`.wep\`), not as Stationery — mode 2 in the AutoMap job-file guide.

### S3 destination (new 2026.1 capability)

Replace the empty pre-release \`deployTarget=\"\"\` with the modern \`destination\` attribute on each Target:

| Job | Destination name |
|---|---|
| [trial-designer.waj](automap-jobs/trial-designer.waj) | \`DocsDesignerTrial\` |
| [trial-express.waj](automap-jobs/trial-express.waj) | \`DocsExpressTrial\` |

Both destinations are defined in the sibling **epublisher-docs** repo's [webworks/deploy-targets.xml](https://github.com/quadralay/epublisher-docs/blob/main/webworks/deploy-targets.xml) via a companion PR (see below). Every federated run passes that file as the \`--deploysettings\` overlay, so destination names resolve without seeding per-user \`deploy.prefs\`.

The S3 targets deploy each guide to:

\`\`\`
s3://static.webworks/docs/epublisher/2026.1/designer/trial
s3://static.webworks/docs/epublisher/2026.1/express/trial
\`\`\`

Served publicly via CloudFront \`E1PFATF4ANO5RM\` as \`static.webworks.com/docs/epublisher/2026.1/{designer,express}/trial\`.

## Companion PR

- **quadralay/epublisher-docs** — adds the two new destination entries to \`deploy-targets.xml\`. This PR is inert until that one merges (destinations would fail to resolve at deploy time). Order: merge the docs PR first, then this one.

## Test plan

- [ ] After the companion PR merges, dry-run each job: \`Invoke-Automap trial-designer.waj --deploysettings ...\deploy-targets.xml --dryrun\` and \`Invoke-Automap trial-express.waj --deploysettings ...\deploy-targets.xml --dryrun\`
- [ ] Confirm the dry run prints the expected PUT set against \`s3://static.webworks/docs/epublisher/2026.1/{designer,express}/trial\`
- [ ] Confirm the CloudFront invalidation set targets the expected paths
- [ ] Live run once dry-run looks correct; verify content lands at \`static.webworks.com/docs/epublisher/2026.1/{designer,express}/trial\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)